### PR TITLE
Fixed error logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Added more recipient field types
+- Fixed error logging.
 
 ## [1.1.0]
 

--- a/src/Helper/WebformHelperSF1601.php
+++ b/src/Helper/WebformHelperSF1601.php
@@ -291,7 +291,8 @@ final class WebformHelperSF1601 implements LoggerInterface {
       return JobResult::success();
     }
     catch (\Exception $e) {
-      $this->error($e->getMessage(), [
+      $this->error('Error: @message', [
+        '@message' => $e->getMessage(),
         'handler_id' => 'os2forms_digital_post',
         'operation' => 'digital post send',
         'webform_submission' => $submission ?? NULL,


### PR DESCRIPTION
Logs the way we're supposed to log, i.e. by using a fixed translatable string as the actual message.
